### PR TITLE
do not load configuration

### DIFF
--- a/osc-requests-tags.py
+++ b/osc-requests-tags.py
@@ -14,7 +14,6 @@ def do_requests_tags(self, subcmd, opts, project):
   ${cmd_usage}
   ${cmd_option_list}
   """
-  conf.get_config()
   api = self.get_api_url()
   requests = get_request_list(api, project = project, req_state =('new', 'review'))
   for request in requests:


### PR DESCRIPTION
I was loading the configuration and that was making the api-url
parameter invalid. You need to load the configuration when running as a
standalone script. When running as an osc plugin, you should not do
that or you overwrite the configuration.

fixes #1

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>